### PR TITLE
Changed the docker file because of issue building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM mhart/alpine-node:11.9.0
 
-RUN npm install -g yarn
+RUN npm config set unsafe-perm true \
+    && npm install -g yarn \
+    && npm config set unsafe-perm false 
 
 RUN mkdir /src
 


### PR DESCRIPTION
I am playing around with containerizing your app with passing the variables through an environment file but every time I build it keeps throwing an error:
```
Error: could not get uid/gid
[ 'nobody', 0 ]
```
After some research I found that using this change worked.  Here is a link to the issue https://github.com/npm/uid-number/issues/3

Also I having trouble figuring out which part is where I place the variables for twitter or meetup.
```
/*eslint-disable */
var twit = new twitter({
    consumer_key: process.env.twitter_ck,
    consumer_secret: process.env.twitter_cs,
    access_token_key: process.env.twitter_atk,
    access_token_secret: process.env.twitter_ats
```
